### PR TITLE
Remove modernstat logo on the page

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -9,7 +9,6 @@ format:
 about:
   id: intro
   template: solana
-  image: assets/img/modernstasts_centered.jpg
 include-in-header:
   text: |
     <style type="text/css">


### PR DESCRIPTION
We have two logo images on the index page, don't need the one in the middle. 